### PR TITLE
update docker compose to latest version of image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.1.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker1:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: broker1
     container_name: broker1
     depends_on:


### PR DESCRIPTION
The version of the book/repo did not work for me because calling
```BASH
kafka-topics --create --bootstrap-server broker1:9092 --topic kinaction_helloworld --partitions 3 --replication-factor 3
```
from inside broker1 or any other broker always failed because of some network error that the other broker/node could not be reached from the network. With the latest image, all problems are gone and I can execute the above command from all three brokers